### PR TITLE
Moves comment into a PR for future reference

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -65,15 +65,6 @@ class PostsController < ApplicationController
   def determine_date_said(params)
     if params[:post][:kid_id].empty?
       nil
-      # This check was added to account for an edge case where date_said == custom_age,
-      # and kid_id is blank.  Params with `custom_age` triggers the elsif block.
-      # This blank kid_id was causing the elsif block to error out
-      # on `Kid.find(params[:post][:kid_id]).birthdate`, as kid_id was blank.
-      # Consequently, the @post.save line in :create was never being reached,
-      # so model validation was never being triggered.
-      # Thusly, this `if` check is now accounting for this edge case,
-      # to ensure that the @post.save line is reached in the :create method,
-      # thereby allowing validation in the model to be checked on kid_id presense.
     elsif params[:post][:kids_age] == 'custom_age'
       years_old  = params[:post][:years_old].to_i.years
       months_old = params[:post][:months_old].to_i.months

--- a/app/views/layouts/_top_navbar.html.erb
+++ b/app/views/layouts/_top_navbar.html.erb
@@ -49,9 +49,10 @@
               <ul class="dropdown-menu">
                 <%= content_tag :li, link_to("Add A Member", new_friend_and_family_path), class: "#{css_class_active_for(new_friend_and_family_path)}" %>
                 <%= content_tag :li, link_to("Current Members", friend_and_families_path), class: "#{css_class_active_for(friend_and_families_path)}" %>
-                  <div class="divider"></div>
 
-                  <%= content_tag :li, link_to("Manage Parents", parents_path), class: "#{css_class_active_for(parents_path)}" %>
+                <div class="divider"></div>
+
+                <%= content_tag :li, link_to("Manage Parents", parents_path), class: "#{css_class_active_for(parents_path)}" %>
               </ul>
             </li>
           <% end %>


### PR DESCRIPTION
In the `posts_controller#determine_date_said` method, the first `if` check was added to account for an edge case where `date_said == custom_age`, and `kid_id` is blank.  Params containing this `custom_age` triggers the `elsif` block. 

This blank `kid_id` was causing the `elsif` block to error out on `Kid.find(params[:post][:kid_id]).birthdate`, as `kid_id` was blank. Consequently, the `@post.save` line in `:create` was never being reached, so model validation was never being triggered. 

Thusly, this `if` check is now accounting for this edge case, to ensure that the `@post.save` line is reached in the `:create` method, thereby allowing validation in the model to be checked on `kid_id` presense.