### PR TITLE
Downcases kid first and last name for Kid#cannot_create_duplicate val…

### DIFF
--- a/app/controllers/kids_controller.rb
+++ b/app/controllers/kids_controller.rb
@@ -33,7 +33,11 @@ class KidsController < ApplicationController
 
     authorize! :update, @kid
 
-    if @kid.update(kid_params)
+    downcased_params = kid_params
+    downcased_params['first_name'] = kid_params['first_name'].downcase
+    downcased_params['last_name']  = kid_params['last_name'].downcase
+
+    if @kid.update(downcased_params)
       redirect_to kids_path
     else
       flash[:error] = "There was a problem updating your kid.  Please try again."
@@ -64,7 +68,12 @@ class KidsController < ApplicationController
   def kid_creation_transaction
     ActiveRecord::Base.transaction do
       begin
-        @kid = Kid.create(kid_params)
+        authorize! :create, Kid
+
+        @kid = Kid.new(kid_params)
+        @kid.first_name = @kid.first_name.downcase
+        @kid.last_name  = @kid.last_name.downcase
+        @kid.save
         current_user.kids << @kid
       rescue Exception => e
         logger.error "User #{current_user.id} experienced #{e.message} when trying to create a new kid"

--- a/app/models/kid.rb
+++ b/app/models/kid.rb
@@ -41,8 +41,8 @@ class Kid < ActiveRecord::Base
       .where(users: { id: parent_ids })
       .where(gender: kid.gender)
       .where(birthdate: kid.birthdate)
-      .where(first_name: kid.first_name)
-      .where(last_name: kid.last_name)
+      .where(first_name: kid.first_name.downcase)
+      .where(last_name: kid.last_name.downcase)
   end
 
   private

--- a/app/views/friend_and_families/index.html.erb
+++ b/app/views/friend_and_families/index.html.erb
@@ -16,7 +16,7 @@
       <% @friends_and_families.each do |fam| %>
         <tr>
           <td><%= User.find(fam.follower_id).full_name %></td>
-          <td><%= Kid.find(fam.kid_id).first_name %></td>
+          <td><%= Kid.find(fam.kid_id).first_name.titleize %></td>
           <td>Yes</td>
           <td><%= yes_or_no fam.can_create_posts %></td>
           <td><%= link_to 'Edit', edit_friend_and_family_path(fam) %></td>

--- a/spec/controllers/kids_controller_spec.rb
+++ b/spec/controllers/kids_controller_spec.rb
@@ -22,9 +22,13 @@ RSpec.describe KidsController, type: :controller do
     end
 
     it "creates a kid with the correct attributes" do
-      expect(Kid.first.first_name).to eq attrs[:first_name]
       expect(Kid.first.birthdate).to eq attrs[:birthdate].to_date
       expect(Kid.first.gender).to eq attrs[:gender]
+    end
+
+    it "downcases the kid's first and last name for Kid#cannot_create_duplicate validation" do
+      expect(Kid.first.first_name).to eq attrs[:first_name].downcase
+      expect(Kid.first.last_name).to eq attrs[:last_name].downcase
     end
 
     it "sets the Kid's #created_by to the user's id" do
@@ -38,6 +42,12 @@ RSpec.describe KidsController, type: :controller do
 
       it "will raise an error when a parent tries to create a kid that already exists underneath the set of parents" do
         post :create, kid: attrs
+
+        expect(response.body).to have_content('A kid with the same first name, last name, birthdate and gender has already been created by your spouse/partner.')
+      end
+
+      it "will raise an error when a parent tries to create a kid that already exists, with the names in a different case, underneath the set of parents" do
+        post :create, kid: { gender: 'female', birthdate: '2010-04-16', first_name: 'jackie', last_name: 'smith', created_by: mom.id.to_s }
 
         expect(response.body).to have_content('A kid with the same first name, last name, birthdate and gender has already been created by your spouse/partner.')
       end
@@ -59,6 +69,11 @@ RSpec.describe KidsController, type: :controller do
 
     it "updates the kid record accordingly" do
       expect(son.birthdate).to eq(date + 1.month)
+    end
+
+    it "downcases the kid's first and last name" do
+      expect(son.first_name).to eq 'jack'
+      expect(son.last_name).to eq 'johnson'
     end
   end
 end

--- a/spec/features/editing_kid_does_not_change_created_by_spec.rb
+++ b/spec/features/editing_kid_does_not_change_created_by_spec.rb
@@ -25,7 +25,8 @@ describe 'Editing a kid does not change their original :created_by' do
       click_button 'Save'
       son.reload
 
-      expect(son.first_name).to eq 'Drew'
+      expect(son.first_name).to eq 'drew'
+      expect(son.last_name).to eq 'johnson'
       expect(son.created_by).to eq dad.id
     end
   end

--- a/spec/models/kid_spec.rb
+++ b/spec/models/kid_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Kid, type: :model do
       let(:dad)    { create :user, first_name: 'Tom' }
       let(:mom)    { create :user, first_name: 'Susan' }
       let(:friend) { create :user, first_name: 'Brian' }
-      let!(:son)   { create :kid, users: [dad, mom], gender: Kid::BOY, birthdate: date, first_name: 'Jack', last_name: 'Johnson', created_by: dad.id }
+      let!(:son)   { create :kid, users: [dad, mom], gender: Kid::BOY, birthdate: date, first_name: 'jack', last_name: 'johnson', created_by: dad.id }
 
       before do
         expect(Kid.count).to eq 1
@@ -27,7 +27,7 @@ RSpec.describe Kid, type: :model do
       context "fellow parent creating duplicate of their own kid" do
         it "will raise an error when a parent tries to create a kid that already exists underneath the set of parents" do
           expect{
-            create :kid, users: [dad, mom], gender: Kid::BOY, birthdate: date, first_name: 'Jack', last_name: 'Johnson', created_by: mom.id
+            create :kid, users: [dad, mom], gender: Kid::BOY, birthdate: date, first_name: 'jack', last_name: 'johnson', created_by: mom.id
             }.to raise_error(ActiveRecord::RecordInvalid)
         end
       end
@@ -35,13 +35,13 @@ RSpec.describe Kid, type: :model do
       context "another user creating a kid with identical information to a kid in the database that is not theirs" do
         it "will create a new kid" do
           expect{
-            create :kid, users: [friend], gender: Kid::BOY, birthdate: date, first_name: 'Jack', last_name: 'Johnson', created_by: friend.id
+            create :kid, users: [friend], gender: Kid::BOY, birthdate: date, first_name: 'jack', last_name: 'johnson', created_by: friend.id
             }.to change{ Kid.count }.by(1)
         end
 
         it "will not raise an error" do
           expect{
-            create :kid, users: [friend], gender: Kid::BOY, birthdate: date, first_name: 'Jack', last_name: 'Johnson', created_by: friend.id
+            create :kid, users: [friend], gender: Kid::BOY, birthdate: date, first_name: 'jack', last_name: 'johnson', created_by: friend.id
             }.to_not raise_error(ActiveRecord::RecordInvalid)
         end
       end


### PR DESCRIPTION
…idation

To ensure that regardless of the case a parent enters a kid's name in, it will still go through the validation for duplicate kid checking